### PR TITLE
Disable node cidr allocation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable node cidr allocation.
+
 ## [1.1.17-gs1] - 2022-07-01
 
 ### Changed

--- a/helm/azure-cloud-controller-manager-app/templates/daemonset.yaml
+++ b/helm/azure-cloud-controller-manager-app/templates/daemonset.yaml
@@ -34,15 +34,12 @@ spec:
         {{- end }}
         args:
         - --profiling=false
-        - --allocate-node-cidrs=true
         - --cloud-config=/etc/kubernetes/config/azure.yaml
         - --cloud-provider=azure
-        - --cluster-cidr={{ .Values.cluster.calico.CIDR }}
         - --configure-cloud-routes=true
         - --controllers=*,-cloud-node
         - --use-service-account-credentials=true
         - --route-reconciliation-period=10s
-        - --node-cidr-mask-size=24
         - --leader-elect=true
         - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
         - --logtostderr=true


### PR DESCRIPTION
To align with aws-cloud-controller-manager, the node cidr allocation should be performed by the provider-independent controller manager rather than the cloud implementation.

For this reason, this PR disables the feature.