### PR TITLE
prepare for capz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add support to make `CPI` run on `CAPZ` based clusters.
+
 ## [1.24.5-gs1] - 2022-09-14
 
 ### Changed

--- a/helm/azure-cloud-controller-manager-app/templates/daemonset.yaml
+++ b/helm/azure-cloud-controller-manager-app/templates/daemonset.yaml
@@ -22,19 +22,24 @@ spec:
       serviceAccountName: {{ .Values.name }}
       hostNetwork: true
       dnsPolicy: Default
-      tolerations:
-      - operator: "Exists"
       nodeSelector:
-        node.kubernetes.io/master: ""
+        {{-  range $key, $value := $.Values.controller.controlPlaneNodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end}}
+      tolerations:
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       containers:
       - name: azure-cloud-controller-manager
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
-        {{- if .Values.resources }}
-        resources: {{ toYaml .Values.resources | nindent 8 }}
-        {{- end }}
         args:
         - --profiling=false
-        - --cloud-config=/etc/kubernetes/config/azure.yaml
+        - --cloud-config={{ .Values.controller.azureCredentialFile }}
         - --cloud-provider=azure
         {{- if .Values.cluster.calico.CIDR }}
         - --cluster-cidr={{ .Values.cluster.calico.CIDR }}
@@ -44,7 +49,9 @@ spec:
         - --use-service-account-credentials=true
         - --route-reconciliation-period=10s
         - --leader-elect=true
+        {{- if .Values.controller.kubeconfigFromHost }}
         - --kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.yaml
+        {{- end }}
         - --logtostderr=true
         - --port={{ .Values.ports.healthcheck }}
         - --v=2

--- a/helm/azure-cloud-controller-manager-app/templates/rbac.yaml
+++ b/helm/azure-cloud-controller-manager-app/templates/rbac.yaml
@@ -22,6 +22,29 @@ rules:
   - {{ .Values.name }}
   verbs:
   - use
+# doesn't exist in upstream yet
+- apiGroups:
+    - ""
+  resources:
+    - serviceaccounts/token
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+# doesn't exist in upstream
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+# below is from https://github.com/kubernetes-sigs/cloud-provider-azure/blob/c33f413c0ef58a7c7af4bdaed87fd1a6e4714f99/helm/cloud-provider-azure/templates/cloud-provider-azure.yaml#L19-L110
 - apiGroups:
   - ""
   resources:

--- a/helm/azure-cloud-controller-manager-app/values.yaml
+++ b/helm/azure-cloud-controller-manager-app/values.yaml
@@ -10,6 +10,12 @@ image:
   name: giantswarm/azure-cloud-controller-manager
   tag: v1.24.5
 
+controller:
+  azureCredentialFile: /etc/kubernetes/config/azure.yaml
+  controlPlaneNodeSelector:
+    "kubernetes.io/role": master
+  kubeconfigFromHost: true
+
 resources:
   limits:
     cpu: 200m


### PR DESCRIPTION
add additional values and conditions to configure CPI for CAPI/CAPZ
based clusters.

Default values reflect the current state of vintage clusters so no
modifications are required.

For CAPI/CAPZ based cluster the app configuration is done via
default-apps-azure


# 2022-12-20 - PR is WIP again

I have to compare upstream again (seems that the RBAC stuff is missing some permissions - which is only an issue in CAPI clusters)
